### PR TITLE
Slight issue with the MQTT retry logic

### DIFF
--- a/Sunrise_CONFIGURE.ino
+++ b/Sunrise_CONFIGURE.ino
@@ -127,9 +127,9 @@ void reconnect()
         delay(5000);
       }
     }
-    if(retries > 1500)
+    else
     {
-    ESP.restart();
+      ESP.restart();
     }
   }
 }


### PR DESCRIPTION
I guess that was a typo, because `retries` can't go over 150, and the code will never call `ESP.restart()`.

Unless I'm missing something. Don't have the hardware right now to test it...